### PR TITLE
complite separate-due-at-date-and-time

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -12,6 +12,7 @@ class ListsController < ApplicationController
 
   def archived
     @todos = current_user.todos.archived.order(due_at: :desc)
+    render_after_cancel_button("archived")
   end
 
   private

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -1,10 +1,17 @@
 module TodosHelper
-  def build_toggle_done_stream(todo)
+  # todoを移動したときのflash のメッセージ
+  MOVEMENT_MESSAGES = {
+    today:    "今日に移動しました",
+    upcoming: "近日予定に移動しました",
+    archived: "アーカイブに移動しました。"
+  }.freeze
+
+  def build_toggle_done_stream(todo,source)
     if todo.due_at.to_date >= Date.current  # 今日以降 かつ done がtrueになったとき
       if todo.done?
-        move(todo, :archived, "アーカイブに移動しました。")
+        move(todo, :archived, MOVEMENT_MESSAGES[:archived],source)
       else
-        toggle_done_in_archive(todo)
+        toggle_done_in_archive(todo,source)
       end
     elsif todo.due_at.to_date < Date.current
       nil
@@ -15,14 +22,14 @@ module TodosHelper
   def build_create_todo_stream(todo, source)
     streams = []
     streams.concat(insert_new_todo_to_list(todo, source))
-    streams.concat(Array(move_todo_by_source_and_due_date(todo, source)))
+    streams.concat(Array(move_todo_stream(todo, source)))
     streams.reduce(:+)
   end
 
   # todo 編集時に発動する Turbo steam
   def build_update_todo_stream(todo, source)
     streams = []
-    streams.concat(Array(move_todo_by_source_and_due_date(todo, source)))
+    streams.concat(Array(move_todo_stream(todo, source)))
     streams.reduce(:+)
   end
 
@@ -43,35 +50,65 @@ module TodosHelper
       ]
     end
 
-    # todoのsource と 日付で処理を分岐
-    def move_todo_by_source_and_due_date(todo, source)
-      if todo.due_at.to_date > Date.current
-        source == "upcoming" ? replace_todo(todo, source) : move(todo, :upcoming,  "近日予定に移動しました")
-      elsif todo.due_at < Date.current
+    # todo作成、編集の両方で使用
+    def move_todo_stream(todo, source)
+      # 過去日ならdone をtrue としておく
+      if todo.due_at.to_date < Date.current && !todo.done?
         todo.update(done: true)
-        move(todo, :archived, "アーカイブに移動しました。")
+      end
+      # 期限日と done による行き先の決定
+      target_list = case todo.due_at.to_date <=> Date.current
+                    when  1 then  :upcoming   # due_at > today
+                    when -1 then  :archived   # due_at < today
+                    else          :today   # due_at == today
+                    end
+       #sourceと同じor doneがtrue なら要素置換、違えば移動
+      if source.to_s == target_list.to_s || todo.done
+        puts ">>> sourceと同じor doneがtrue"
+        replace_todo(todo, source)
       else
-        source == "today" ? replace_todo(todo, source) : move(todo, :today, "今日に移動しました")
+        puts ">>> todo を移動"
+        message = MOVEMENT_MESSAGES[target_list]
+        move(todo, target_list, message, source)
       end
     end
-
-    def move(todo, list, notice)
+    # list は移動先、notice はflash の文章,source は現在の画面
+    def move(todo, list, notice,source)
       flash.now[:notice] = notice
-      turbo_stream.remove(dom_id(todo)) +
-      turbo_stream.prepend("todos_#{list}", render(partial: "todos/todo", locals: { todo: todo, source: list.to_s })) +
-      turbo_stream.replace("flash", partial: "shared/flash")
+      # 指定されたlist内で todoと同じ日のtodos をsource_todos とする
+      source_todos = current_user.todos.send(source).where(due_at: todo.due_at.all_day)
+      streams = [
+        turbo_stream.remove(dom_id(todo)),
+        turbo_stream.prepend("todos_#{list}", render(partial: "todos/todo", locals: { todo: todo, source: list.to_s })),
+        turbo_stream.replace("flash", partial: "shared/flash")
+      ]
+
+      if source_todos.empty?
+        group_id = "todos_group_#{todo.due_at.to_date}"
+        streams << turbo_stream.remove(group_id)
+      end
+      streams.reduce(:+)
     end
 
     def replace_todo(todo, source)
-      turbo_stream.replace(
+      source_todos =  current_user.todos.send(source).where(due_at: todo.due_at.all_day)
+      # 初めてのtodo作成の場合
+      if source_todos.count == 1 && todo.saved_change_to_id?
+        turbo_stream.append(
+        "todos_list_wrapper",
+        render(partial: "lists/todos_list", locals: { todos: source_todos, source: source })
+      )
+      else
+        turbo_stream.update(
         dom_id(todo),
         render(partial: "todos/todo", locals: { todo: todo, source: source })
       )
+      end      
     end
 
-    def toggle_done_in_archive(todo)
-      notice = (todo.due_at.to_date == Date.current) ? "今日に移動しました" : "近日予定に移動しました"
-      list = (todo.due_at.to_date == Date.current) ? :today : :upcoming
-      move(todo, list, notice)
+    def toggle_done_in_archive(todo,source)
+      notice = (todo.due_at.to_date == Time.zone.now.to_date) ? "今日に移動しました" : "近日予定に移動しました"
+      list = (todo.due_at.to_date == Time.zone.now.to_date) ? :today : :upcoming
+      move(todo, list, notice,source)
     end
 end

--- a/app/javascript/controllers/edit_controller.js
+++ b/app/javascript/controllers/edit_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
   };
   connect() {
     // 要素に dblclick イベントをバインド
-    this.element.addEventListener('dblclick', this.navigate.bind(this));
+    this.element.addEventListener('click', this.navigate.bind(this));
   }
 
   navigate() {

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -30,7 +30,10 @@ class Todo < ApplicationRecord
 
   private
     def merge_due_date_and_time
-      # 日付の00:00をデフォルトタイムスタンプとする
+      # doneボタンなど入力しない場合にエラーにならない対策
+      return unless due_date
+      # 日付の23:59:59をデフォルトタイムスタンプとする
+      # 日付が変わるまで today or upcoming のtodo が移動しなくなる
       timestamp = due_date.in_time_zone.beginning_of_day
       if has_time?
         if due_time.present?
@@ -38,7 +41,7 @@ class Todo < ApplicationRecord
           hour, min = due_time.split(":").map(&:to_i)
           timestamp = timestamp.change(hour: hour, min: min)
         end
-        # due_time が空なら「00:00」のまま
+        # due_time が空なら「23:59:59」のまま
       end
       self.due_at = timestamp
     end

--- a/app/views/lists/_todos_list.html.erb
+++ b/app/views/lists/_todos_list.html.erb
@@ -1,7 +1,7 @@
-<% @todos.group_by { |todo| todo.due_at.to_date }.each do |date, todos_for_date| %> <%# todos_for_date は同じ日(6/1等)の塊のtodo%>
+<% todos.group_by { |todo| todo.due_at.to_date }.each do |date, todos_for_date| %> <%# todos_for_date は同じ日(6/1等)の塊のtodo%>
   <div class="mb-6">
     <!-- 日付見出し -->
-    <h2 class="text-xl font-semibold text-gray-700 mb-2">
+    <h2 class="text-xl font-semibold text-gray-700 mb-2" id ="todos_group_<%= date %>" >
       <%= I18n.l(date, format: :todo) %>
     </h2>
     <!-- タスク一覧 -->

--- a/app/views/lists/archived.html.erb
+++ b/app/views/lists/archived.html.erb
@@ -1,19 +1,10 @@
 <div class="max-w-2xl mx-auto px-4 py-6">
   <!-- 見出し -->
   <h1 class="text-2xl font-bold mb-2">アーカイブ</h1>
-  <p class="flex items-center text-gray-500 text-sm mb-6">
-    <!-- todoアイコン -->
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mr-1 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-        d="M5 13l4 4L19 7" />
-    </svg>
-    <%= pluralize(@todos.count, "件") %>のタスク
-  </p>
 
   <!-- タスク一覧 -->
-  <div>
-    <%= render "todos_list", source: "archived" %>
+  <div id= "todos_list_wrapper">
+    <%= render "todos_list",todos: @todos, source: "archived" %>
   </div>
-
 
 </div>

--- a/app/views/lists/today.html.erb
+++ b/app/views/lists/today.html.erb
@@ -1,18 +1,10 @@
 <div class="max-w-2xl mx-auto px-4 py-6">
   <!-- 見出し -->
   <h1 class="text-2xl font-bold mb-2">今日</h1>
-  <p class="flex items-center text-gray-500 text-sm mb-6">
-    <!-- todoアイコン -->
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mr-1 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-        d="M5 13l4 4L19 7" />
-    </svg>
-    <%= pluralize(@todos.count, "件") %>のタスク
-  </p>
 
   <!-- 日付ごとのグループ化 -->
-  <div>
-    <%= render "todos_list", source: "today" %>
+  <div id= "todos_list_wrapper">
+    <%= render "todos_list", todos: @todos, source: "today" %>
   </div>
 
   <!-- タスク追加リンク -->

--- a/app/views/lists/upcoming.html.erb
+++ b/app/views/lists/upcoming.html.erb
@@ -1,18 +1,10 @@
 <div class="max-w-2xl mx-auto px-4 py-6">
   <!-- 見出し -->
   <h1 class="text-2xl font-bold mb-2">近日予定</h1>
-  <p class="flex items-center text-gray-500 text-sm mb-6">
-    <!-- todoアイコン -->
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mr-1 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-        d="M5 13l4 4L19 7" />
-    </svg>
-    <%= pluralize(@todos.count, "件") %>のタスク
-  </p>
 
   <!-- タスク一覧 -->
-  <div>
-    <%= render "todos_list", source: "upcoming" %>
+  <div id= "todos_list_wrapper">
+    <%= render "todos_list", todos: @todos, source: "upcoming" %>
   </div>
 
   <!-- タスク追加リンク -->

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -1,19 +1,12 @@
- <li id="<%= dom_id(todo) %>" class="group flex items-center justify-between gap-6 px-6 py-4 border-b hover:bg-gray-50 transition-colors">
+ <li id="<%= dom_id(todo) %>" class="group flex items-center justify-between gap-6 px-6 py-4 border-b rounded-sm hover:bg-gray-200 transition-colors">
 
-  <!-- ハンドルとチェックボックス -->
   <div class="flex items-center space-x-3 shrink-0">
-    <!-- 6点ハンドル 機能拡張する場合 -->
-    <%# <div class="w-4 h-6 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-move">
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-        <path d="M2 4a2 2 0 114 0 2 2 0 01-4 0zM2 10a2 2 0 114 0 2 2 0 01-4 0zM2 16a2 2 0 114 0 2 2 0 01-4 0zM8 4a2 2 0 114 0 2 2 0 01-4 0zM8 10a2 2 0 114 0 2 2 0 01-4 0zM8 16a2 2 0 114 0 2 2 0 01-4 0z"/>
-      </svg>
-    </div> %>
-
     <!-- チェックボタン -->
     <%= form_with model: todo,
                   data: { "turbo-method": :patch,
                           controller: "done-button-submit"  }, 
                   class: "shrink-0" do |f| %>
+      <%= hidden_field_tag :source, source %>
       <%= f.check_box :done, 
                       data: { action: "change->done-button-submit#submit"},
                       class: "w-6 h-6 text-blue-500 border-gray-300 rounded focus:ring-blue-400"  %>
@@ -23,8 +16,8 @@
   <!-- 本文（タイトル・説明・日付）ダブルクリックで編集 -->
   <div class="flex-1  min-w-0 mx-4 cursor-pointer <%= 'opacity-50 line-through' if todo.done? %> "
         data-controller="edit"
-        data-edit-url-value="<%= edit_todo_path(todo, source: source, format: :turbo_stream) %>">
-
+        data-edit-url-value="<%= edit_todo_path(todo, source: source, format: :turbo_stream) %>"
+        title="クリックで編集">
     <p class="text-base font-semibold text-gray-800"><%= todo.title %></p>
 
     <% if todo.description.present? %>
@@ -83,6 +76,12 @@
     </summary>
     <ul class="absolute right-0 mt-2 w-36 bg-white border rounded shadow-lg z-10">
       <li>
+        <%= link_to "編集", 
+              edit_todo_path(todo, source: source), 
+              data: { turbo_stream: true },
+              class: "block w-full text-left px-4 py-2 hover:bg-gray-100 text-gray-800" %>
+      </li>
+      <li>
         <%= button_to "削除", todo_path(todo), 
               method: :delete, 
               data: { turbo_stream: true },
@@ -90,9 +89,8 @@
       </li>
       <li>
         <%= button_to "複製", 
-              copy_todo_path(todo),
+              copy_todo_path(todo, source: source),
               method: :post,
-              params: { source: source },
               data: { turbo_stream: true},
               class: "block w-full text-left px-4 py-2 hover:bg-gray-100" %>
       </li>

--- a/app/views/todos/_todo_edit.html.erb
+++ b/app/views/todos/_todo_edit.html.erb
@@ -38,7 +38,7 @@
                   action:             "change->time-toggle#toggle"
                 },
                 class: "mt-1" %>
-          <%= f.label :has_time, "時刻を設定する", class: "text-sm text-gray-700" %>
+          <%= f.label :has_time, "実施時間を設定する", class: "text-sm text-gray-700" %>
 
           <div data-time-toggle-target="timepicker" class="hidden">
             <%= f.text_field :due_time,

--- a/app/views/todos/_todo_new.html.erb
+++ b/app/views/todos/_todo_new.html.erb
@@ -41,7 +41,7 @@
                   action:             "change->time-toggle#toggle"
                 },
                 class: "mt-1" %>
-          <%= f.label :has_time, "時刻を設定する", class: "text-sm text-gray-700" %>
+          <%= f.label :has_time, "実施時間を設定する", class: "text-sm text-gray-700" %>
 
           <div data-time-toggle-target="timepicker" class="hidden">
             <%= f.text_field :due_time,

--- a/app/views/todos/update.turbo_stream.erb
+++ b/app/views/todos/update.turbo_stream.erb
@@ -1,10 +1,14 @@
 <% source = params[:source].presence %>  <%# 空文字もnil とする。 %>
+<% puts source %>
 
 <% if @todo.errors.any? %>
+  <% puts "validation エラー: フォーム再描画" %>
   <%# validation error: フォーム partial へ差し替えてエラーメッセージ付きで再描画 %>
   <%= turbo_stream.replace dom_id(@todo), partial: "todo_edit", locals: { todo: @todo, source: source } %>
-<% elsif source %>
-  <%= build_update_todo_stream(@todo,source) %> <%# 内容の変更の場合(新規作成と編集の時に使用) %>
+<% elsif @todo.saved_change_to_done? %>
+  <% puts "done チェック変更: build_toggle_done_stream 実行" %>
+  <%= build_toggle_done_stream(@todo,source) %>
 <% else %>
-  <%= build_toggle_done_stream(@todo) %>
+  <% puts "通常の編集: build_update_todo_stream 実行" %>
+  <%= build_update_todo_stream(@todo,source) %> <%# 内容の変更の場合 %>
 <% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -13,6 +13,7 @@ ja:
         password_confirmation: パスワード（確認用）
       todo:
         title: 'タイトル'
+        due_time: '実施時間'
   date:
     abbr_day_names:
       - 日

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -251,97 +251,6 @@
           }
         }
       },
-      "/home/vscode/environment/todo-rails-application/app/controllers/lists_controller.rb": {
-        "lines": [
-          1,
-          1,
-          1,
-          9,
-          9,
-          null,
-          null,
-          1,
-          1,
-          1,
-          null,
-          null,
-          1,
-          1,
-          null,
-          null,
-          1,
-          null,
-          1,
-          10,
-          10,
-          10,
-          0,
-          0,
-          0,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          0,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
-        ],
-        "branches": {
-          "[:if, 0, 23, 10, 38, 13]": {
-            "[:then, 1, 24, 12, 30, 13]": 0,
-            "[:else, 2, 32, 12, 37, 13]": 0
-          }
-        }
-      },
-      "/home/vscode/environment/todo-rails-application/app/controllers/application_controller.rb": {
-        "lines": [
-          1,
-          1,
-          1,
-          1,
-          0,
-          null,
-          null,
-          null,
-          1,
-          null,
-          null,
-          1,
-          72,
-          72,
-          null,
-          null,
-          1,
-          null,
-          null,
-          1,
-          26,
-          1,
-          null,
-          null,
-          null
-        ],
-        "branches": {
-          "[:if, 0, 4, 2, 6, 5]": {
-            "[:then, 1, 5, 4, 5, 35]": 0,
-            "[:else, 2, 4, 2, 6, 5]": 1
-          },
-          "[:if, 3, 21, 4, 23, 7]": {
-            "[:then, 4, 22, 6, 22, 28]": 1,
-            "[:else, 5, 21, 4, 23, 7]": 25
-          }
-        }
-      },
       "/home/vscode/environment/todo-rails-application/app/controllers/users/registrations_controller.rb": {
         "lines": [
           null,
@@ -414,35 +323,96 @@
           }
         }
       },
-      "/home/vscode/environment/todo-rails-application/app/controllers/users/sessions_controller.rb": {
+      "/home/vscode/environment/todo-rails-application/app/controllers/application_controller.rb": {
         "lines": [
-          null,
-          null,
           1,
-          null,
           1,
-          19,
-          null,
-          null,
-          null,
           1,
-          11,
-          null,
-          null,
-          null,
           1,
           0,
           null,
           null,
+          null,
           1,
           null,
           null,
           1,
-          4,
+          72,
+          72,
+          null,
+          null,
+          1,
+          null,
+          null,
+          1,
+          26,
+          1,
+          null,
           null,
           null
         ],
-        "branches": {}
+        "branches": {
+          "[:if, 0, 4, 2, 6, 5]": {
+            "[:then, 1, 5, 4, 5, 35]": 0,
+            "[:else, 2, 4, 2, 6, 5]": 1
+          },
+          "[:if, 3, 21, 4, 23, 7]": {
+            "[:then, 4, 22, 6, 22, 28]": 1,
+            "[:else, 5, 21, 4, 23, 7]": 25
+          }
+        }
+      },
+      "/home/vscode/environment/todo-rails-application/app/controllers/lists_controller.rb": {
+        "lines": [
+          1,
+          1,
+          1,
+          9,
+          9,
+          null,
+          null,
+          1,
+          1,
+          1,
+          null,
+          null,
+          1,
+          1,
+          null,
+          null,
+          1,
+          null,
+          1,
+          10,
+          10,
+          10,
+          0,
+          0,
+          0,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          0,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "branches": {
+          "[:if, 0, 23, 10, 38, 13]": {
+            "[:then, 1, 24, 12, 30, 13]": 0,
+            "[:else, 2, 32, 12, 37, 13]": 0
+          }
+        }
       },
       "/home/vscode/environment/todo-rails-application/app/controllers/users/passwords_controller.rb": {
         "lines": [
@@ -485,6 +455,48 @@
         ],
         "branches": {}
       },
+      "/home/vscode/environment/todo-rails-application/app/controllers/static_pages_controller.rb": {
+        "lines": [
+          1,
+          1,
+          null,
+          null,
+          1,
+          null,
+          null
+        ],
+        "branches": {}
+      },
+      "/home/vscode/environment/todo-rails-application/app/controllers/users/sessions_controller.rb": {
+        "lines": [
+          null,
+          null,
+          1,
+          null,
+          1,
+          19,
+          null,
+          null,
+          null,
+          1,
+          11,
+          null,
+          null,
+          null,
+          1,
+          0,
+          null,
+          null,
+          1,
+          null,
+          null,
+          1,
+          4,
+          null,
+          null
+        ],
+        "branches": {}
+      },
       "/home/vscode/environment/todo-rails-application/app/controllers/users/confirmations_controller.rb": {
         "lines": [
           null,
@@ -515,18 +527,6 @@
           null,
           1,
           0,
-          null,
-          null
-        ],
-        "branches": {}
-      },
-      "/home/vscode/environment/todo-rails-application/app/controllers/static_pages_controller.rb": {
-        "lines": [
-          1,
-          1,
-          null,
-          null,
-          1,
           null,
           null
         ],
@@ -740,7 +740,7 @@
         "branches": {}
       }
     },
-    "timestamp": 1750147718
+    "timestamp": 1750148879
   },
   "Integration Tests": {
     "coverage": {

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2025-06-17T08:08:38+00:00">2025-06-17T08:08:38+00:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2025-06-17T08:27:59+00:00">2025-06-17T08:27:59+00:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">


### PR DESCRIPTION
### 機能追加(todoリスト)

- [x]  日付はmustだけど、時間は未設定でもよい仕様にする
- [x]  日付指定してないのにarchivedに飛んでいく
- [x]  todoをダブルクリック→クリック で編集に変更
- [x]  マウスをホバーすると 「クリックで編集する」を表示する

### バグ修正

- はじめてのtodoを作成すると、todoが追加されない現象
- todo が移動した後に日付だけ残る
- archived で編集すると、content missingとなった

　　→listsコントローラーの設定がされていなかった

### コードの変更箇所

- user モデルの merge_due_date_and_time メソッドtimestampのデフォの日付を23:59:59 に変更
    
    → 0:00 だと過去になってarchivedに移動するから
    
- replace_todo にはじめてtodoを作成する場合を追加
- source , target_list を網羅できるように変更