### PR TITLE
fix display hover bug

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,12 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+/* app/views/todo/_todo.html.erb のCSS */
+/* スマホ・タブレット用の場合は縦3点メニューを表示させる */
+@media (hover: none) {
+  /* タッチ時は強制表示 */
+  details.dropdown-summary summary {
+    opacity: 1 ;
+  }
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,2 @@
 @import 'tailwindcss';
+

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -66,15 +66,7 @@
     <% end %>
   </div>
 
-  <!-- スマホ・タブレット用の場合は縦3点メニューを表示させる -->
-  <style>
-    @media (hover: none) {
-      /* タッチ時は強制表示 */
-      .dropdown-summary summary {
-        opacity: 1 !important;
-      }
-    }
-  </style>
+
 
   <!-- 右の縦3点メニュー -->
   <details data-controller="dropdown" class="relative ml-2 shrink-0 dropdown-summary">

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -13,7 +13,7 @@
     <% end %>
   </div>
 
-  <!-- 本文（タイトル・説明・日付）ダブルクリックで編集 -->
+  <!-- 本文（タイトル・説明・日付）クリックで編集 -->
   <div class="flex-1  min-w-0 mx-4 cursor-pointer <%= 'opacity-50 line-through' if todo.done? %> "
         data-controller="edit"
         data-edit-url-value="<%= edit_todo_path(todo, source: source, format: :turbo_stream) %>"
@@ -66,8 +66,18 @@
     <% end %>
   </div>
 
+  <!-- スマホ・タブレット用の場合は縦3点メニューを表示させる -->
+  <style>
+    @media (hover: none) {
+      /* タッチ時は強制表示 */
+      .dropdown-summary summary {
+        opacity: 1 !important;
+      }
+    }
+  </style>
+
   <!-- 右の縦3点メニュー -->
-  <details data-controller="dropdown" class="relative ml-2 shrink-0">
+  <details data-controller="dropdown" class="relative ml-2 shrink-0 dropdown-summary">
     <summary class="w-7 h-7 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-500 hover:text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"


### PR DESCRIPTION
## 概要
<!-- このPRの目的・背景を2行程度で記載してください -->
右の縦3点メニューはマウスがホバーすると表示するような仕組みにしていたが、
マウス表示のないスマホやタブレットの場合はホバーができないため、常時表示するように切り替えた。

## 修正内容
<!-- 主な変更点を箇条書きで記載 -->
- app/views/todo/_todo.html.erb にCSSを追加した。
- CSS の実装はTailswindCSSがメインであるが、TailwindCSSではhoverがない場合の処理が書けないので、_todo.html.erb にstyle で直書きした

## 影響範囲
<!-- この変更が影響する範囲（画面や機能）を記載 -->
- todo一覧(today, upcoming, archived ) をスマホ or タブレットなどのマウスがない画面で見た場合、縦3点メニューが追加されている

## 動作確認
<!-- レビュアーが実際に確認できる内容を記載 -->
### 確認手順
1. today 画面を開き、todoを少なくとも1つ作成する。(today 画面でなくてもよいが、便宜上today画面としている)
2 chorme であればF12 をおして、開発者モードを開き「Toggle devise toolbar 」をクリックする
3. Dimensions: Responsive をクリックし、iphone や ipadなどを選択

### 期待される結果
- todo に右の縦3点メニューが表示されていることを確認

### スクリーンショット（UI変更がある場合）
<!-- Before/Afterの画像を貼付 -->
**Before**
<img src="https://github.com/user-attachments/assets/a938d705-0008-476e-8aac-ed5e4c105904" width="200">



**After**
<img width="192" alt="image" src="https://github.com/user-attachments/assets/f637e51d-624f-4cc0-b2d8-2acd96952950" />


## レビュー観点
<!-- レビュアーにチェックしてほしいポイントを記載 -->
- [ ] **機能面**: 仕様通りに動作するか
- [ ] **コード品質**: 可読性、保守性、設計パターンの適用
- [ ] **ブラウザ動作確認**: 対象ページでの動作（特に確認したい操作：）
- [x] **自動テスト**: RSpec/Minitestが正常に通る
- [x] **CI/CD**: GitHub ActionsのCIステータスが ✅

## デプロイ・運用
<!-- デプロイに関する情報を記載 -->
- **マイグレーション**: 無
- **環境変数の追加**: 無
- **特別なデプロイ手順**: 無
- **破壊的変更**:  有 (!important を使用)
- **依存関係の変更**: 無

## 補足
<!-- 関連情報や注意点を記載 -->
- **関連Issue**: #36 


## チェックリスト（PR作成者用）
- [x] 自分でコードレビューを実施した
- [x] コミットメッセージが適切である
- [x] 不要なコメントやデバッグコードを削除した
- [x] 関連するIssueをリンクした