### PR TITLE
Fix/issues 50 flash messages bug

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -44,7 +44,6 @@ class TodosController < ApplicationController
   def edit
     respond_to do |format|
       format.turbo_stream
-      format.html  { redirect_to today_path } # TODO: turboの実装しか考えてないのでpathは別途考える
     end
   end
 
@@ -52,7 +51,6 @@ class TodosController < ApplicationController
     @todo.update(todo_params)
     respond_to do |format|
       format.turbo_stream
-      format.html  { redirect_to today_path } # TODO: turboの実装しか考えてないのでpathは別途考える
     end
   end
 
@@ -97,4 +95,5 @@ class TodosController < ApplicationController
                                  :due_date, :due_time,  # 仮想属性
                                  :has_time, :position, :done)
   end
+
 end

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -95,5 +95,4 @@ class TodosController < ApplicationController
                                  :due_date, :due_time,  # 仮想属性
                                  :has_time, :position, :done)
   end
-
 end

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -120,7 +120,7 @@ module TodosHelper
         render(partial: "todos/todo", locals: { todo: todo, source: source })
       )
       # todoを編集する場合
-      else 
+      else
         streams << turbo_stream.replace(
         dom_id(todo),
         render(partial: "todos/todo", locals: { todo: todo, source: source })

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -6,6 +6,10 @@ module TodosHelper
     archived: "アーカイブに移動しました。"
   }.freeze
 
+  REPLACE_TODO_MESSAGE = {
+    create: "todoを作成しました",
+    update: "todoを更新しました"
+  }
   def build_toggle_done_stream(todo, source)
     if todo.due_at.to_date >= Date.current  # 今日以降 かつ done がtrueになったとき
       if todo.done?
@@ -39,7 +43,7 @@ module TodosHelper
     source_todos = current_user.todos.send(source).where(due_at: todo.due_at.all_day)
     streams = [
       turbo_stream.remove(dom_id(todo)),
-      turbo_stream.replace("flash", partial: "shared/flash")
+      turbo_stream.update("flash", partial: "shared/flash")
     ]
     if source_todos.empty?
       group_id = "todos_group_#{todo.due_at.to_date}"
@@ -53,7 +57,6 @@ module TodosHelper
     # add_todo_buttonに入った新規todo を todos_source に移動する
     def insert_new_todo_to_list(todo, source)
       [
-        turbo_stream.append("todos_#{source}", partial: "todos/todo", locals: { todo: todo, source: source }),
         turbo_stream.replace("add_todo_button_#{source}", partial: "lists/add_todo_button", locals: { source: source })
       ]
     end
@@ -72,7 +75,9 @@ module TodosHelper
       end
       # sourceと同じor doneがtrue なら要素置換、違えば移動
       if source.to_s == target_list.to_s || todo.done
-        replace_todo(todo, source)
+        notice = todo.saved_change_to_id? ? :create : :update
+        message = REPLACE_TODO_MESSAGE[notice]
+        replace_todo(todo, source, message)
       else
         message = MOVEMENT_MESSAGES[target_list]
         move(todo, target_list, message, source)
@@ -86,7 +91,7 @@ module TodosHelper
       streams = [
         turbo_stream.remove(dom_id(todo)),
         turbo_stream.prepend("todos_#{list}", render(partial: "todos/todo", locals: { todo: todo, source: list.to_s })),
-        turbo_stream.replace("flash", partial: "shared/flash")
+        turbo_stream.update("flash", partial: "shared/flash")
       ]
 
       if source_todos.empty?
@@ -96,20 +101,32 @@ module TodosHelper
       streams.reduce(:+)
     end
 
-    def replace_todo(todo, source)
+    def replace_todo(todo, source, message)
+      flash.now[:notice] = message
+      streams = [
+        turbo_stream.update("flash", partial: "shared/flash")
+      ]
       source_todos =  current_user.todos.send(source).where(due_at: todo.due_at.all_day)
       # 初めてのtodo作成の場合
       if source_todos.count == 1 && todo.saved_change_to_id?
-        turbo_stream.append(
+        streams << turbo_stream.append(
         "todos_list_wrapper",
         render(partial: "lists/todos_list", locals: { todos: source_todos, source: source })
       )
-      else
-        turbo_stream.replace(
+      # todoを作成する場合(すでにその日付にtodoがある場合)
+      elsif todo.saved_change_to_id?
+        streams << turbo_stream.append(
+        "todos_#{source}",
+        render(partial: "todos/todo", locals: { todo: todo, source: source })
+      )
+      # todoを編集する場合
+      else 
+        streams << turbo_stream.replace(
         dom_id(todo),
         render(partial: "todos/todo", locals: { todo: todo, source: source })
       )
       end
+      streams.reduce(:+)
     end
 
     def toggle_done_in_archive(todo, source)

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -25,7 +25,7 @@ module TodosHelper
   # todo 作成時に発動する Turbo stream
   def build_create_todo_stream(todo, source)
     streams = []
-    streams.concat(insert_new_todo_to_list(todo, source))
+    streams.concat(relocate_add_button(todo, source))
     streams.concat(Array(move_todo_stream(todo, source)))
     streams.reduce(:+)
   end
@@ -54,8 +54,8 @@ module TodosHelper
 
   private
 
-    # add_todo_buttonに入った新規todo を todos_source に移動する
-    def insert_new_todo_to_list(todo, source)
+    # add_todo_buttonをもとに戻す
+    def relocate_add_button(todo, source)
       [
         turbo_stream.replace("add_todo_button_#{source}", partial: "lists/add_todo_button", locals: { source: source })
       ]

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -90,7 +90,7 @@
               class: "block w-full text-left px-4 py-2 hover:bg-gray-100 text-red-600" %>
       </li>
       <li>
-        <%= button_to "複製", 
+        <%= button_to "コピー", 
               copy_todo_path(todo, source: source),
               method: :post,
               data: { turbo_stream: true},

--- a/app/views/todos/copy.turbo_stream.erb
+++ b/app/views/todos/copy.turbo_stream.erb
@@ -1,3 +1,4 @@
 <% source = params[:source]%>
 <%= turbo_stream.prepend "todos_#{source}", partial: "todos/todo", locals: { todo: @todo, source: source } %>
-<%= turbo_stream.replace "flash", partial: "shared/flash", locals: { notice: "タスクを複製しました" } %>
+<%= flash.now[:notice] = "タスクを複製しました" %>
+<%= turbo_stream.update "flash", partial: "shared/flash" %>

--- a/app/views/todos/copy.turbo_stream.erb
+++ b/app/views/todos/copy.turbo_stream.erb
@@ -1,4 +1,4 @@
 <% source = params[:source]%>
 <%= turbo_stream.prepend "todos_#{source}", partial: "todos/todo", locals: { todo: @todo, source: source } %>
-<%= flash.now[:notice] = "タスクを複製しました" %>
+<%= flash.now[:notice] = "タスクをコピーしました" %>
 <%= turbo_stream.update "flash", partial: "shared/flash" %>

--- a/app/views/todos/new.turbo_stream.erb
+++ b/app/views/todos/new.turbo_stream.erb
@@ -1,3 +1,4 @@
 <% source = params[:source]%>
+<%= turbo_stream.update("flash", partial: "shared/flash") %>
 <%= turbo_stream.replace "add_todo_button_#{source}", 
       partial: "todo_new", locals: { todo: @todo, source: source } %>


### PR DESCRIPTION
## 概要
<!-- この PR の目的・背景を 1～2 行で記載してください（例：バグ修正、UI改善、パフォーマンス向上など） -->

## 修正点
<!-- 主な変更点を箇条書きで記載してください（例：バリデーション追加、デザイン調整など） -->
- insert_new_todo_to_listメソッド(現relocate_add_buttonメソッド)の中にあったturbo_stream.appendを削除
- flash のturbo_stream をreplace からupdateに変更
- todo作成時・編集時のflashメッセージ追加
- 複製 という言葉ではなくコピーに変更

## バグの原因
- turbo_stream.replaceとすることで、id = flashが消えてしまい、flashメッセージを表示しようとしてもid がなくなっているので表示できなかった。
- 直接的な原因ではないが、insert_new_todo_to_listメソッド(現relocate_add_buttonメソッド)の中にあったturbo_stream.appendによってtodo が2つ作成されており、ほかのバグを引き起こす可能性があった

## 影響範囲
<!-- この変更が影響する画面・機能・ファイルなどを記載してください（例：todo一覧画面、Userモデルなど） -->
- flash メッセージの表示
- 縦3点マークを押したときの表示が、複製からコピーに変更

## 動作確認手順
<!-- レビュアーが確認しやすいように、操作手順を具体的に記載してください -->
1. 既存のtodoを削除(flash メッセージで 「todoを削除しました」とでる)
2. todoを追加をクリック(さっきのflash メッセージがきえる)
3. タイトルを入力して作成ボタンを押す 

### 期待結果
<!-- 上記の操作を行った際に、どう表示・動作すべきかを記載してください -->
- flash メッセージで 「todo を作成しました」を確認

### スクリーンショット（UI 変更がある場合）
<!-- 変更前後のスクリーンショットやGIFを貼ってください。なければ省略可能です -->
**Before**
![Image](https://github.com/user-attachments/assets/d4546cd2-6399-4e3b-8ee2-e4ed557bb6d5)
**After**
![bug_flash_messages](https://github.com/user-attachments/assets/3c3a40e3-3de3-41a3-baa4-6d9e58e3a597)

## テスト
<!-- 自動・手動を問わず、実施したテストの種類をチェックしてください -->
- [ ] 自動テストを追加／更新した（RSpec, Minitest 等）
- [ ] 手動での動作確認を行った
- [ ] CI（GitHub Actions）が正常に通過する

## レビューポイント
<!-- レビュアーに特に見てほしい点があればチェックを入れてください -->
- [ ] **機能**：仕様どおりに動作するか  
- [ ] **コード品質**：可読性・保守性  
- [ ] **セキュリティ**：権限・バリデーション・入力チェック  
- [ ] **パフォーマンス**：処理速度やリソース使用量  
- [ ] **CI**：GitHub Actions のワークフローが成功しているか  

## デプロイ／運用
<!-- 該当する項目にチェックを入れて、必要に応じて補足してください -->
- **マイグレーション**：有／無（テーブル追加、カラム変更など）
- **環境変数の追加**：有／無（.envやGitHub Secrets等）
- **破壊的変更の有無**：有／無（既存データへの影響など）

## 関連
<!-- 関連するIssueやPRがあれば番号で記載してください -->
- Issue: fix #50 

## チェックリスト（作成者用）
<!-- PR作成前に確認した内容にチェックを入れてください -->
- [ ] 自身で動作確認・コードレビューを完了した  
- [ ] 不要なコメント・デバッグコードを削除した  
- [ ] コミットメッセージがわかりやすく記述されている  
- [ ] 関連Issueがリンクされている（あれば）  
